### PR TITLE
Fix error that's occurring because the main branch doesn’t exist in t…

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -36,6 +36,9 @@ jobs:
     - name: Run tests
       run: mvn test
 
+    - name: Fetch all branches
+      run: git fetch --all
+
     - name: Deploy to Main
       run: |
         git config --global user.name 'github-actions'


### PR DESCRIPTION
…he local repository when the workflow is trying to check it out. Fixed by ensuring the main branch is fetched before attempting to check it out.