### PR TITLE
The --allow-unrelated-histories flag is added to the git merge comman…

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -44,7 +44,7 @@ jobs:
         git config --global user.name 'github-actions'
         git config --global user.email 'github-actions@github.com'
         git checkout main
-        git merge develop
+        git merge develop --allow-unrelated-histories
         git push origin main
 
   sync:
@@ -60,5 +60,5 @@ jobs:
         git config --global user.name 'github-actions'
         git config --global user.email 'github-actions@github.com'
         git checkout develop
-        git merge main
+        git merge main --allow-unrelated-histories
         git push origin develop


### PR DESCRIPTION
The --allow-unrelated-histories flag is added to the git merge command to allow merging branches with unrelated histories.