### PR TITLE
use the default GITHUB_TOKEN provided by GitHub Actions, you can modi…

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -49,3 +49,5 @@ jobs:
         git checkout main
         git merge origin/develop --allow-unrelated-histories
         git push origin main
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Use the default token


### PR DESCRIPTION
…fy the push command to use it. However, note that the default token has limited permissions, especially for pushing to protected branches.